### PR TITLE
Move dependencies to main build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,28 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    ext {
+        setup = [compileSdk: 23,
+                 targetSdk : 22,
+                 minSdk    : 10,
+                 buildTools: "23.0.0"]
+
+        versions = [support    : "24.1.1",
+                    supportTest: "0.4",
+                    dexmaker   : "1.2"]
+
+        deps = [supportAppCompat : "com.android.support:appcompat-v7:$ext.versions.support",
+                supportTestRunner: "com.android.support.test:runner:$ext.versions.supportTest",
+                supportTestRules : "com.android.support.test:rules:$ext.versions.supportTest",
+                mockitoCore      : 'org.mockito:mockito-core:1.9.5',
+                dexmaker         : "com.google.dexmaker:dexmaker:$ext.versions.dexmaker",
+                dexmakerMockito  : "com.google.dexmaker:dexmaker-mockito:$ext.versions.dexmaker"]
+    }
+
     repositories {
         jcenter()
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -17,13 +17,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.0'
+    compileSdkVersion setup.compileSdk
+    buildToolsVersion setup.buildTools
 
     defaultConfig {
         applicationId "com.jmolsmobile.landscapevideocapture_sample"
-        minSdkVersion 10
-        targetSdkVersion 22
+        minSdkVersion setup.minSdk
+        targetSdkVersion setup.targetSdk
         versionCode 13
         versionName "1.1.4"
     }
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.3.0'
+    compile deps.supportAppCompat
 //    compile project(':library')
 
     compile 'com.github.JeroenMols:LandscapeVideoCamera:1.1.4'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,12 +18,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.kt3k.coveralls'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.0'
+    compileSdkVersion setup.compileSdk
+    buildToolsVersion setup.buildTools
 
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 22
+        minSdkVersion setup.minSdk
+        targetSdkVersion setup.targetSdk
         versionCode 1
         versionName "1.0"
 
@@ -38,11 +38,11 @@ android {
 }
 
 dependencies {
-    androidTestCompile 'com.android.support.test:runner:0.4'
-    androidTestCompile 'com.android.support.test:rules:0.4'
-    androidTestCompile 'org.mockito:mockito-core:1.9.5'
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestCompile deps.supportTestRunner
+    androidTestCompile deps.supportTestRules
+    androidTestCompile deps.mockitoCore
+    androidTestCompile deps.dexmaker
+    androidTestCompile deps.dexmakerMockito
 }
 
 coveralls {


### PR DESCRIPTION
Its easier to update dependencies, update CI servers file and track library changes between submodules moving dependencies to main `build.grade` or what do you think?
