### PR TITLE
Add button to toggle flash on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This library provides a full and reusable custom camera, which:
   * Max video duration
   * audio/video codec
   * switch between front and rear facing camera
+  * flash activation
   * ...
 
 ## How to use
@@ -75,6 +76,7 @@ This library provides a full and reusable custom camera, which:
          builder.frameRate(framesPerSec);
          builder.showRecordingTime();         // Show the elapsed recording time
          builder.noCameraToggle();            // Remove button to toggle between front and back camera
+         builder.noFlashToggle();            // Remove button to toggle flash on/off
 
          // Get the CaptureConfiguration
          CaptureConfiguration configuration = builder.build();

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This library provides a full and reusable custom camera, which:
          builder.frameRate(framesPerSec);
          builder.showRecordingTime();         // Show the elapsed recording time
          builder.noCameraToggle();            // Remove button to toggle between front and back camera
-         builder.noFlashToggle();            // Remove button to toggle flash on/off
+         builder.setFlashOption(PredefinedCaptureConfigurations.FlashOption.START_OFF); // Show button to toggle flash on/off and start recording with flash Off (other PredefinedCaptureConfigurations.FlashOption can be choosen) 
 
          // Get the CaptureConfiguration
          CaptureConfiguration configuration = builder.build();

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
     }
 }

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <!-- Add these permissions to your own app. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-feature android:name="android.hardware.camera" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/example/src/main/java/com/jmolsmobile/landscapevideocapture_sample/CaptureDemoFragment.java
+++ b/example/src/main/java/com/jmolsmobile/landscapevideocapture_sample/CaptureDemoFragment.java
@@ -20,6 +20,7 @@ import com.jmolsmobile.landscapevideocapture.VideoCaptureActivity;
 import com.jmolsmobile.landscapevideocapture.configuration.CaptureConfiguration;
 import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureQuality;
 import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureResolution;
+import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.FlashOption;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
@@ -58,6 +59,7 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
 
     private final String[] RESOLUTION_NAMES = new String[]{"1080p", "720p", "480p"};
     private final String[] QUALITY_NAMES = new String[]{"high", "medium", "low"};
+    private final String[] FLASH_OPTIONS = new String[]{"force off","force on", "start off", "start on"};
 
     private String statusMessage = null;
     private String filename = null;
@@ -66,6 +68,7 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
     private TextView statusTv;
     private Spinner resolutionSp;
     private Spinner qualitySp;
+    private Spinner flashSp;
 
     private RelativeLayout advancedRl;
     private EditText filenameEt;
@@ -74,7 +77,7 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
     private EditText fpsEt;
     private CheckBox showTimerCb;
     private CheckBox allowFrontCameraCb;
-    private CheckBox allowFlashCb;
+
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -93,8 +96,6 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
         maxFilesizeEt = (EditText) rootView.findViewById(R.id.et_filesize);
         showTimerCb = (CheckBox) rootView.findViewById(R.id.cb_showtimer);
         allowFrontCameraCb = (CheckBox) rootView.findViewById(R.id.cb_show_camera_switch);
-        allowFlashCb = (CheckBox) rootView.findViewById(R.id.cb_show_flash_switch);
-
 
         if (savedInstanceState != null) {
             statusMessage = savedInstanceState.getString(KEY_STATUSMESSAGE);
@@ -119,6 +120,12 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
         adapter2.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         qualitySp = (Spinner) rootView.findViewById(R.id.sp_quality);
         qualitySp.setAdapter(adapter2);
+
+        final ArrayAdapter<String> adapter3 = new ArrayAdapter<String>(getActivity(),
+                android.R.layout.simple_spinner_item, FLASH_OPTIONS);
+        adapter3.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        flashSp = (Spinner) rootView.findViewById(R.id.sp_flash);
+        flashSp.setAdapter(adapter3);
     }
 
     @Override
@@ -261,9 +268,9 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
         if (!allowFrontCameraCb.isChecked()) {
             builder.noCameraToggle();
         }
-        if (!allowFlashCb.isChecked()) {
-            builder.noFlashToggle();
-        }
+
+        final FlashOption flashOption = getFlashOption(flashSp.getSelectedItemPosition());
+        builder.setFlashOption(flashOption);
         
         return builder.build();
     }
@@ -277,6 +284,12 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
     private CaptureResolution getResolution(int position) {
         final CaptureResolution[] resolution = new CaptureResolution[]{CaptureResolution.RES_1080P,
                 CaptureResolution.RES_720P, CaptureResolution.RES_480P};
+        return resolution[position];
+    }
+
+    private FlashOption getFlashOption(int position) {
+        final FlashOption[] resolution = new FlashOption[]{FlashOption.HIDE,FlashOption.HIDE_ON,
+                FlashOption.START_OFF, FlashOption.START_ON};
         return resolution[position];
     }
 

--- a/example/src/main/java/com/jmolsmobile/landscapevideocapture_sample/CaptureDemoFragment.java
+++ b/example/src/main/java/com/jmolsmobile/landscapevideocapture_sample/CaptureDemoFragment.java
@@ -288,7 +288,7 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
     }
 
     private FlashOption getFlashOption(int position) {
-        final FlashOption[] resolution = new FlashOption[]{FlashOption.HIDE,FlashOption.HIDE_ON,
+        final FlashOption[] resolution = new FlashOption[]{FlashOption.NO_FLASH,FlashOption.ALWAYS,
                 FlashOption.START_OFF, FlashOption.START_ON};
         return resolution[position];
     }

--- a/example/src/main/java/com/jmolsmobile/landscapevideocapture_sample/CaptureDemoFragment.java
+++ b/example/src/main/java/com/jmolsmobile/landscapevideocapture_sample/CaptureDemoFragment.java
@@ -16,6 +16,11 @@
 
 package com.jmolsmobile.landscapevideocapture_sample;
 
+import com.jmolsmobile.landscapevideocapture.VideoCaptureActivity;
+import com.jmolsmobile.landscapevideocapture.configuration.CaptureConfiguration;
+import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureQuality;
+import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureResolution;
+
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
@@ -43,11 +48,6 @@ import android.widget.RelativeLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 
-import com.jmolsmobile.landscapevideocapture.VideoCaptureActivity;
-import com.jmolsmobile.landscapevideocapture.configuration.CaptureConfiguration;
-import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureQuality;
-import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureResolution;
-
 import java.util.List;
 
 public class CaptureDemoFragment extends Fragment implements OnClickListener {
@@ -74,6 +74,7 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
     private EditText fpsEt;
     private CheckBox showTimerCb;
     private CheckBox allowFrontCameraCb;
+    private CheckBox allowFlashCb;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -92,6 +93,7 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
         maxFilesizeEt = (EditText) rootView.findViewById(R.id.et_filesize);
         showTimerCb = (CheckBox) rootView.findViewById(R.id.cb_showtimer);
         allowFrontCameraCb = (CheckBox) rootView.findViewById(R.id.cb_show_camera_switch);
+        allowFlashCb = (CheckBox) rootView.findViewById(R.id.cb_show_flash_switch);
 
 
         if (savedInstanceState != null) {
@@ -258,6 +260,9 @@ public class CaptureDemoFragment extends Fragment implements OnClickListener {
         }
         if (!allowFrontCameraCb.isChecked()) {
             builder.noCameraToggle();
+        }
+        if (!allowFlashCb.isChecked()) {
+            builder.noFlashToggle();
         }
         
         return builder.build();

--- a/example/src/main/res/drawable/ic_flash_black_48dp.xml
+++ b/example/src/main/res/drawable/ic_flash_black_48dp.xml
@@ -1,0 +1,4 @@
+<vector android:height="48dp" android:viewportHeight="24.0"
+    android:viewportWidth="24.0" android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M7,2v11h3v9l7,-12h-4l4,-8z"/>
+</vector>

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -116,6 +116,26 @@
                     android:checked="true"
                     android:gravity="center_vertical"
                     android:text="@string/allow_frontcamera" />
+
+
+                <ImageView
+                        android:id="@+id/iv_flash"
+                        android:layout_width="36dp"
+                        android:layout_height="56dp"
+                        android:layout_below="@id/iv_front"
+                        android:layout_marginLeft="16dp"
+                        android:src="@drawable/ic_flash_black_48dp" />
+
+                <CheckBox
+                        android:id="@+id/cb_show_flash_switch"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_alignBottom="@id/iv_flash"
+                        android:layout_below="@id/iv_front"
+                        android:layout_marginLeft="72dp"
+                        android:checked="true"
+                        android:gravity="center_vertical"
+                        android:text="@string/allow_flash" />
             </RelativeLayout>
 
             <RelativeLayout

--- a/example/src/main/res/layout/fragment_main.xml
+++ b/example/src/main/res/layout/fragment_main.xml
@@ -126,16 +126,14 @@
                         android:layout_marginLeft="16dp"
                         android:src="@drawable/ic_flash_black_48dp" />
 
-                <CheckBox
-                        android:id="@+id/cb_show_flash_switch"
-                        android:layout_width="match_parent"
+                <Spinner
+                        android:id="@+id/sp_flash"
+                        android:layout_width="175dp"
                         android:layout_height="wrap_content"
                         android:layout_alignBottom="@id/iv_flash"
-                        android:layout_below="@id/iv_front"
-                        android:layout_marginLeft="72dp"
-                        android:checked="true"
-                        android:gravity="center_vertical"
-                        android:text="@string/allow_flash" />
+                        android:layout_alignTop="@id/iv_flash"
+                        android:layout_marginLeft="72dp" />
+
             </RelativeLayout>
 
             <RelativeLayout

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="show_timer">Show Timer</string>
     <string name="allow_frontcamera">Allow front facing camera</string>
     <string name="allow_flash">Allow flash toggle</string>
+    <string name="start_flash">Flash start ON</string>
     <string name="privacy">privacy policy</string>
     <string name="privacy_url">http://jeroenmols.com/apps/landscapevideocamera/privacy_policy.html</string>
     <string name="enter_fps_hint">Enter FPS</string>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="github_url">https://github.com/jeroenmols/LandscapeVideoCamera</string>
     <string name="show_timer">Show Timer</string>
     <string name="allow_frontcamera">Allow front facing camera</string>
+    <string name="allow_flash">Allow flash toggle</string>
     <string name="privacy">privacy policy</string>
     <string name="privacy_url">http://jeroenmols.com/apps/landscapevideocamera/privacy_policy.html</string>
     <string name="enter_fps_hint">Enter FPS</string>

--- a/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfigurationBuilderTest.java
+++ b/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfigurationBuilderTest.java
@@ -113,9 +113,35 @@ public class CaptureConfigurationBuilderTest {
     }
 
     @Test
-    public void builtConfigurationAllowFlash() throws Exception {
-        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).noFlashToggle().build();
+    public void builtConfigurationHideFlashToggleAndFlashStartOFF() throws Exception {
+        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).setFlashOption(PredefinedCaptureConfigurations.FlashOption.HIDE).build();
 
-        assertThat(configuration.getAllowFlash()).isFalse();
+        assertThat(configuration.getAllowFlashToggle()).isFalse();
+        assertThat(configuration.getIfFlashStartOn()).isFalse();
     }
+
+    @Test
+    public void builtConfigurationHideFlashToggleAndFlashStartON() throws Exception {
+        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).setFlashOption(PredefinedCaptureConfigurations.FlashOption.HIDE_ON).build();
+
+        assertThat(configuration.getAllowFlashToggle()).isFalse();
+        assertThat(configuration.getIfFlashStartOn()).isTrue();
+    }
+
+    @Test
+    public void builtConfigurationShowFlashToggleAndFlashStartON() throws Exception {
+        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).setFlashOption(PredefinedCaptureConfigurations.FlashOption.START_ON).build();
+
+        assertThat(configuration.getAllowFlashToggle()).isTrue();
+        assertThat(configuration.getIfFlashStartOn()).isTrue();
+    }
+
+    @Test
+    public void builtConfigurationShowFlashToggleAndFlashStartOFF() throws Exception {
+        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).setFlashOption(PredefinedCaptureConfigurations.FlashOption.START_OFF).build();
+
+        assertThat(configuration.getAllowFlashToggle()).isTrue();
+        assertThat(configuration.getIfFlashStartOn()).isFalse();
+    }
+
 }

--- a/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfigurationBuilderTest.java
+++ b/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfigurationBuilderTest.java
@@ -114,7 +114,7 @@ public class CaptureConfigurationBuilderTest {
 
     @Test
     public void builtConfigurationHideFlashToggleAndFlashStartOFF() throws Exception {
-        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).setFlashOption(PredefinedCaptureConfigurations.FlashOption.HIDE).build();
+        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).setFlashOption(PredefinedCaptureConfigurations.FlashOption.NO_FLASH).build();
 
         assertThat(configuration.getAllowFlashToggle()).isFalse();
         assertThat(configuration.getIfFlashStartOn()).isFalse();
@@ -122,7 +122,7 @@ public class CaptureConfigurationBuilderTest {
 
     @Test
     public void builtConfigurationHideFlashToggleAndFlashStartON() throws Exception {
-        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).setFlashOption(PredefinedCaptureConfigurations.FlashOption.HIDE_ON).build();
+        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).setFlashOption(PredefinedCaptureConfigurations.FlashOption.ALWAYS).build();
 
         assertThat(configuration.getAllowFlashToggle()).isFalse();
         assertThat(configuration.getIfFlashStartOn()).isTrue();

--- a/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfigurationBuilderTest.java
+++ b/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfigurationBuilderTest.java
@@ -1,11 +1,11 @@
 package com.jmolsmobile.landscapevideocapture.configuration;
 
-import android.support.test.runner.AndroidJUnit4;
-
 import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureResolution;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import android.support.test.runner.AndroidJUnit4;
 
 import static com.jmolsmobile.landscapevideocapture.configuration.CaptureConfiguration.Builder;
 import static com.jmolsmobile.landscapevideocapture.configuration.CaptureConfiguration.MBYTE_TO_BYTE;
@@ -110,5 +110,12 @@ public class CaptureConfigurationBuilderTest {
         CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).noCameraToggle().build();
 
         assertThat(configuration.getAllowFrontFacingCamera()).isFalse();
+    }
+
+    @Test
+    public void builtConfigurationAllowFlash() throws Exception {
+        CaptureConfiguration configuration = new Builder(MOCK_RESOLUTION, MOCK_QUALITY).noFlashToggle().build();
+
+        assertThat(configuration.getAllowFlash()).isFalse();
     }
 }

--- a/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/recorder/VideoRecorderTest.java
+++ b/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/recorder/VideoRecorderTest.java
@@ -27,19 +27,17 @@ import com.jmolsmobile.landscapevideocapture.configuration.CaptureConfiguration;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import android.hardware.Camera;
 import android.media.CamcorderProfile;
 import android.media.MediaRecorder;
+import android.support.test.runner.AndroidJUnit4;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.util.Arrays;
-import java.util.Collection;
 
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
@@ -57,25 +55,8 @@ import static org.mockito.Mockito.verify;
 
 
 @SuppressWarnings("deprecation")
-@RunWith(value = Parameterized.class)
+@RunWith(value = AndroidJUnit4.class)
 public class VideoRecorderTest extends MockitoTestCase {
-
-    private boolean FlashStatus;
-
-    // Inject via constructor
-    public VideoRecorderTest(boolean FlashStatus) {
-        this.FlashStatus = FlashStatus;
-    }
-
-    // name attribute is optional, provide an unique name for test
-    // multiple parameters, uses Collection<Object[]>
-    @Parameterized.Parameters()
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {true},
-                {false}
-        });
-    }
 
     @Test
     public void openCameraWhenCreated() throws Exception {
@@ -98,11 +79,11 @@ public class VideoRecorderTest extends MockitoTestCase {
     public void startRecordingWhenNotStarted() throws Exception {
         final VideoRecorder spyRecorder =
                 spy(new VideoRecorder(null, mock(CaptureConfiguration.class), null, mock(CameraWrapper.class), mock(SurfaceHolder.class), false));
-        doNothing().when(spyRecorder).startRecording(FlashStatus);
+        doNothing().when(spyRecorder).startRecording();
 
-        spyRecorder.toggleRecording(FlashStatus);
+        spyRecorder.toggleRecording();
 
-        verify(spyRecorder, times(1)).startRecording(FlashStatus);
+        verify(spyRecorder, times(1)).startRecording();
     }
 
     @Test
@@ -112,7 +93,7 @@ public class VideoRecorderTest extends MockitoTestCase {
         doReturn(true).when(spyRecorder).isRecording();
         doNothing().when(spyRecorder).stopRecording(anyString());
 
-        spyRecorder.toggleRecording(FlashStatus);
+        spyRecorder.toggleRecording();
 
         verify(spyRecorder, times(1)).stopRecording(null);
     }
@@ -123,7 +104,7 @@ public class VideoRecorderTest extends MockitoTestCase {
                 spy(new VideoRecorder(null, mock(CaptureConfiguration.class), null, mock(CameraWrapper.class), mock(SurfaceHolder.class), false));
         spyRecorder.releaseAllResources();
 
-        spyRecorder.toggleRecording(FlashStatus);
+        spyRecorder.toggleRecording();
     }
 
     @Test
@@ -133,7 +114,7 @@ public class VideoRecorderTest extends MockitoTestCase {
         final VideoRecorderInterface mockInterface = mock(VideoRecorderInterface.class);
         final VideoRecorder recorder = new VideoRecorder(mockInterface, mock(CaptureConfiguration.class), null, mockWrapper, mock(SurfaceHolder.class), false);
 
-        recorder.startRecording(FlashStatus);
+        recorder.startRecording();
 
         verify(mockInterface, times(1)).onRecordingFailed("Unable to record video");
     }
@@ -144,7 +125,7 @@ public class VideoRecorderTest extends MockitoTestCase {
         final MediaRecorder mockRecorder = mock(MediaRecorder.class);
 
         final VideoRecorder spyRecorder = createSpyRecorder(mockInterface, mockRecorder);
-        spyRecorder.startRecording(FlashStatus);
+        spyRecorder.startRecording();
 
         verify(mockInterface, times(1)).onRecordingStarted();
     }
@@ -156,7 +137,7 @@ public class VideoRecorderTest extends MockitoTestCase {
         doThrow(new IllegalStateException()).when(mockRecorder).prepare();
 
         final VideoRecorder spyRecorder = createSpyRecorder(mockInterface, mockRecorder);
-        spyRecorder.startRecording(FlashStatus);
+        spyRecorder.startRecording();
 
         verify(mockRecorder, never()).start();
     }
@@ -168,7 +149,7 @@ public class VideoRecorderTest extends MockitoTestCase {
         doThrow(new IOException()).when(mockRecorder).prepare();
 
         final VideoRecorder spyRecorder = createSpyRecorder(mockInterface, mockRecorder);
-        spyRecorder.startRecording(FlashStatus);
+        spyRecorder.startRecording();
 
         verify(mockRecorder, never()).start();
     }
@@ -180,7 +161,7 @@ public class VideoRecorderTest extends MockitoTestCase {
         doThrow(new IllegalStateException()).when(mockRecorder).start();
 
         final VideoRecorder spyRecorder = createSpyRecorder(mockInterface, mockRecorder);
-        spyRecorder.startRecording(FlashStatus);
+        spyRecorder.startRecording();
 
         verify(mockInterface, never()).onRecordingStarted();
     }
@@ -192,7 +173,7 @@ public class VideoRecorderTest extends MockitoTestCase {
         doThrow(new RuntimeException()).when(mockRecorder).start();
 
         final VideoRecorder spyRecorder = createSpyRecorder(mockInterface, mockRecorder);
-        spyRecorder.startRecording(FlashStatus);
+        spyRecorder.startRecording();
 
         verify(mockInterface, times(1)).onRecordingFailed("Unable to record video with given settings");
     }

--- a/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureViewTest.java
+++ b/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureViewTest.java
@@ -16,6 +16,14 @@
 
 package com.jmolsmobile.landscapevideocapture.view;
 
+import com.jmolsmobile.landscapevideocapture.MockitoTestCase;
+import com.jmolsmobile.landscapevideocapture.R;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
@@ -26,14 +34,6 @@ import android.support.test.rule.UiThreadTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.view.View;
 import android.widget.ImageView;
-
-import com.jmolsmobile.landscapevideocapture.MockitoTestCase;
-import com.jmolsmobile.landscapevideocapture.R;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertFalse;
@@ -89,7 +89,7 @@ public class VideoCaptureViewTest extends MockitoTestCase {
     public void recordBtnShouldNotifyListener() {
         final RecordingButtonInterface mockBtnInterface = mock(RecordingButtonInterface.class);
         performClickOnButton(R.id.videocapture_recordbtn_iv, mockBtnInterface);
-        Mockito.verify(mockBtnInterface, Mockito.times(1)).onRecordButtonClicked();
+        Mockito.verify(mockBtnInterface, Mockito.times(1)).onRecordButtonClicked(false);
     }
 
     @UiThreadTest

--- a/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureViewTest.java
+++ b/library/src/androidTest/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureViewTest.java
@@ -89,7 +89,7 @@ public class VideoCaptureViewTest extends MockitoTestCase {
     public void recordBtnShouldNotifyListener() {
         final RecordingButtonInterface mockBtnInterface = mock(RecordingButtonInterface.class);
         performClickOnButton(R.id.videocapture_recordbtn_iv, mockBtnInterface);
-        Mockito.verify(mockBtnInterface, Mockito.times(1)).onRecordButtonClicked(false);
+        Mockito.verify(mockBtnInterface, Mockito.times(1)).onRecordButtonClicked();
     }
 
     @UiThreadTest

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
@@ -16,6 +16,15 @@
 
 package com.jmolsmobile.landscapevideocapture;
 
+import com.jmolsmobile.landscapevideocapture.camera.CameraWrapper;
+import com.jmolsmobile.landscapevideocapture.camera.NativeCamera;
+import com.jmolsmobile.landscapevideocapture.configuration.CaptureConfiguration;
+import com.jmolsmobile.landscapevideocapture.recorder.AlreadyUsedException;
+import com.jmolsmobile.landscapevideocapture.recorder.VideoRecorder;
+import com.jmolsmobile.landscapevideocapture.recorder.VideoRecorderInterface;
+import com.jmolsmobile.landscapevideocapture.view.RecordingButtonInterface;
+import com.jmolsmobile.landscapevideocapture.view.VideoCaptureView;
+
 import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -27,34 +36,34 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.Toast;
 
-import com.jmolsmobile.landscapevideocapture.camera.CameraWrapper;
-import com.jmolsmobile.landscapevideocapture.camera.NativeCamera;
-import com.jmolsmobile.landscapevideocapture.configuration.CaptureConfiguration;
-import com.jmolsmobile.landscapevideocapture.recorder.AlreadyUsedException;
-import com.jmolsmobile.landscapevideocapture.recorder.VideoRecorder;
-import com.jmolsmobile.landscapevideocapture.recorder.VideoRecorderInterface;
-import com.jmolsmobile.landscapevideocapture.view.RecordingButtonInterface;
-import com.jmolsmobile.landscapevideocapture.view.VideoCaptureView;
-
 public class VideoCaptureActivity extends Activity implements RecordingButtonInterface, VideoRecorderInterface {
 
     public static final int RESULT_ERROR = 753245;
+
     private static final int REQUESTCODE_SWITCHCAMERA = 578465;
 
     public static final String EXTRA_OUTPUT_FILENAME = "com.jmolsmobile.extraoutputfilename";
+
     public static final String EXTRA_CAPTURE_CONFIGURATION = "com.jmolsmobile.extracaptureconfiguration";
+
     public static final String EXTRA_ERROR_MESSAGE = "com.jmolsmobile.extraerrormessage";
 
     private static final String EXTRA_FRONTFACINGCAMERASELECTED = "com.jmolsmobile.extracamerafacing";
+
     private static final String SAVED_RECORDED_BOOLEAN = "com.jmolsmobile.savedrecordedboolean";
+
     protected static final String SAVED_OUTPUT_FILENAME = "com.jmolsmobile.savedoutputfilename";
 
     private boolean mVideoRecorded = false;
+
     VideoFile mVideoFile = null;
+
     private CaptureConfiguration mCaptureConfiguration;
 
     private VideoCaptureView mVideoCaptureView;
+
     private VideoRecorder mVideoRecorder;
+
     private boolean isFrontFacingCameraSelected;
 
     @Override
@@ -68,7 +77,9 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
         initializeCaptureConfiguration(savedInstanceState);
 
         mVideoCaptureView = (VideoCaptureView) findViewById(R.id.videocapture_videocaptureview_vcv);
-        if (mVideoCaptureView == null) return; // Wrong orientation
+        if (mVideoCaptureView == null) {
+            return; // Wrong orientation
+        }
 
         initializeRecordingUI();
     }
@@ -91,6 +102,7 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
         mVideoCaptureView.setRecordingButtonInterface(this);
         mVideoCaptureView.setCameraSwitchingEnabled(mCaptureConfiguration.getAllowFrontFacingCamera());
         mVideoCaptureView.setCameraFacing(isFrontFacingCameraSelected);
+        mVideoCaptureView.setFlashSwitchingEnabled(mCaptureConfiguration.getAllowFlash(), isFrontFacingCameraSelected);
 
         if (mVideoRecorded) {
             mVideoCaptureView.updateUIRecordingFinished(getVideoThumbnail());
@@ -145,6 +157,12 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
         intent.putExtra(EXTRA_FRONTFACINGCAMERASELECTED, isFrontFacingSelected);
         startActivityForResult(intent, REQUESTCODE_SWITCHCAMERA);
         overridePendingTransition(R.anim.from_middle, R.anim.to_middle);
+    }
+
+    @Override
+    public void onFlashButtonClicked(boolean isFlashOn) {
+        mVideoRecorder.setFlash(isFlashOn);
+
     }
 
     @Override
@@ -211,7 +229,9 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
     }
 
     private boolean generateVideoRecorded(final Bundle savedInstanceState) {
-        if (savedInstanceState == null) return false;
+        if (savedInstanceState == null) {
+            return false;
+        }
         return savedInstanceState.getBoolean(SAVED_RECORDED_BOOLEAN, false);
     }
 

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
@@ -134,9 +134,9 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
     }
 
     @Override
-    public void onRecordButtonClicked(boolean useFlash) {
+    public void onRecordButtonClicked() {
         try {
-            mVideoRecorder.toggleRecording(useFlash);
+            mVideoRecorder.toggleRecording();
         } catch (AlreadyUsedException e) {
             CLog.d(CLog.ACTIVITY, "Cannot toggle recording after cleaning up all resources");
         }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
@@ -99,10 +99,12 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
                 new CameraWrapper(new NativeCamera(), display.getRotation()),
                 mVideoCaptureView.getPreviewSurfaceHolder(),
                 isFrontFacingCameraSelected);
+
         mVideoCaptureView.setRecordingButtonInterface(this);
         mVideoCaptureView.setCameraSwitchingEnabled(mCaptureConfiguration.getAllowFrontFacingCamera());
         mVideoCaptureView.setCameraFacing(isFrontFacingCameraSelected);
         mVideoCaptureView.setFlashSwitchingEnabled(mCaptureConfiguration.getAllowFlash(), isFrontFacingCameraSelected);
+        mVideoCaptureView.setFlashStartOption(mCaptureConfiguration.getIfFlashStartOn());
 
         if (mVideoRecorded) {
             mVideoCaptureView.updateUIRecordingFinished(getVideoThumbnail());
@@ -127,9 +129,9 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
     }
 
     @Override
-    public void onRecordButtonClicked() {
+    public void onRecordButtonClicked(boolean useFlash) {
         try {
-            mVideoRecorder.toggleRecording();
+            mVideoRecorder.toggleRecording(useFlash);
         } catch (AlreadyUsedException e) {
             CLog.d(CLog.ACTIVITY, "Cannot toggle recording after cleaning up all resources");
         }
@@ -161,8 +163,7 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
 
     @Override
     public void onFlashButtonClicked(boolean isFlashOn) {
-        mVideoRecorder.setFlash(isFlashOn);
-
+        mCaptureConfiguration.setIfFlashStartOn(isFlashOn);
     }
 
     @Override

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
@@ -103,7 +103,7 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
         mVideoCaptureView.setRecordingButtonInterface(this);
         mVideoCaptureView.setCameraSwitchingEnabled(mCaptureConfiguration.getAllowFrontFacingCamera());
         mVideoCaptureView.setCameraFacing(isFrontFacingCameraSelected);
-        mVideoCaptureView.setFlashSwitchingEnabled(mCaptureConfiguration.getAllowFlash(), isFrontFacingCameraSelected);
+        mVideoCaptureView.setFlashSwitchingEnabled(mCaptureConfiguration.getAllowFlashToggle(), isFrontFacingCameraSelected);
         mVideoCaptureView.setFlashStartOption(mCaptureConfiguration.getIfFlashStartOn());
 
         if (mVideoRecorded) {

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/VideoCaptureActivity.java
@@ -66,6 +66,8 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
 
     private boolean isFrontFacingCameraSelected;
 
+    private CameraWrapper mCameraWrapper;
+
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -93,10 +95,13 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
 
     private void initializeRecordingUI() {
         Display display = ((WindowManager) getSystemService(WINDOW_SERVICE)).getDefaultDisplay();
+
+        mCameraWrapper = new CameraWrapper(new NativeCamera(), display.getRotation());
+
         mVideoRecorder = new VideoRecorder(this,
                 mCaptureConfiguration,
                 mVideoFile,
-                new CameraWrapper(new NativeCamera(), display.getRotation()),
+                mCameraWrapper,
                 mVideoCaptureView.getPreviewSurfaceHolder(),
                 isFrontFacingCameraSelected);
 
@@ -104,7 +109,7 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
         mVideoCaptureView.setCameraSwitchingEnabled(mCaptureConfiguration.getAllowFrontFacingCamera());
         mVideoCaptureView.setCameraFacing(isFrontFacingCameraSelected);
         mVideoCaptureView.setFlashSwitchingEnabled(mCaptureConfiguration.getAllowFlashToggle(), isFrontFacingCameraSelected);
-        mVideoCaptureView.setFlashStartOption(mCaptureConfiguration.getIfFlashStartOn());
+        mVideoCaptureView.setFlashStartOption(mCameraWrapper, mCaptureConfiguration.getIfFlashStartOn());
 
         if (mVideoRecorded) {
             mVideoCaptureView.updateUIRecordingFinished(getVideoThumbnail());
@@ -163,7 +168,7 @@ public class VideoCaptureActivity extends Activity implements RecordingButtonInt
 
     @Override
     public void onFlashButtonClicked(boolean isFlashOn) {
-        mCaptureConfiguration.setIfFlashStartOn(isFlashOn);
+        mCameraWrapper.setFlash(isFlashOn);
     }
 
     @Override

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/CameraWrapper.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/CameraWrapper.java
@@ -60,8 +60,8 @@ public class CameraWrapper {
             throw new OpenCameraException(OpenType.NOCAMERA);
     }
 
-    public void setFlash(){
-        mNativeCamera.setFlash();
+    public void setFlash(boolean isFlashOn){
+        mNativeCamera.setFlash(isFlashOn);
     }
 
     public void prepareCameraForRecording() throws PrepareCameraException {

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/CameraWrapper.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/CameraWrapper.java
@@ -16,6 +16,9 @@
 
 package com.jmolsmobile.landscapevideocapture.camera;
 
+import com.jmolsmobile.landscapevideocapture.CLog;
+import com.jmolsmobile.landscapevideocapture.camera.OpenCameraException.OpenType;
+
 import android.annotation.TargetApi;
 import android.graphics.ImageFormat;
 import android.hardware.Camera;
@@ -26,9 +29,6 @@ import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.view.SurfaceHolder;
-
-import com.jmolsmobile.landscapevideocapture.CLog;
-import com.jmolsmobile.landscapevideocapture.camera.OpenCameraException.OpenType;
 
 import java.io.IOException;
 import java.util.List;
@@ -58,6 +58,10 @@ public class CameraWrapper {
 
         if (mNativeCamera.getNativeCamera() == null)
             throw new OpenCameraException(OpenType.NOCAMERA);
+    }
+
+    public void setFlash(){
+        mNativeCamera.setFlash();
     }
 
     public void prepareCameraForRecording() throws PrepareCameraException {

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/NativeCamera.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/NativeCamera.java
@@ -16,12 +16,15 @@
 
 package com.jmolsmobile.landscapevideocapture.camera;
 
+import com.jmolsmobile.landscapevideocapture.CLog;
+
 import android.hardware.Camera;
 import android.hardware.Camera.CameraInfo;
 import android.hardware.Camera.Parameters;
 import android.view.SurfaceHolder;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Wrapper around the native camera class so all camera access
@@ -128,9 +131,33 @@ public class NativeCamera {
         return false;
     }
 
-    public void setFlash(){
-        params.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
-        camera.setParameters(params);
+    public void setFlash(boolean isFlashOn){
+
+        if(camera != null) {
+            params = camera.getParameters();
+        }
+
+        if(params!=null) {
+            List<String> supportedFlashModes = params.getSupportedFlashModes();
+            if (supportedFlashModes != null) {
+                try {
+                    if (isFlashOn) {
+                        if (supportedFlashModes.contains(Camera.Parameters.FLASH_MODE_TORCH)) {
+                            params.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
+                            camera.setParameters(params);
+                        }
+                    } else {
+                        if (supportedFlashModes.contains(Parameters.FLASH_MODE_OFF)) {
+                            params.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
+                            camera.setParameters(params);
+                        }
+                    }
+                } catch (RuntimeException RE) {
+                    CLog.e(CLog.CAMERA, "Set Torch param failed : " + RE);
+                }
+            }
+
+        }
     }
 
 }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/NativeCamera.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/NativeCamera.java
@@ -133,31 +133,25 @@ public class NativeCamera {
 
     public void setFlash(boolean isFlashOn){
 
-        if(camera != null) {
-            params = camera.getParameters();
-        }
-
-        if(params!=null) {
-            List<String> supportedFlashModes = params.getSupportedFlashModes();
-            if (supportedFlashModes != null) {
-                try {
-                    if (isFlashOn) {
-                        if (supportedFlashModes.contains(Camera.Parameters.FLASH_MODE_TORCH)) {
-                            params.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
-                            camera.setParameters(params);
-                        }
-                    } else {
-                        if (supportedFlashModes.contains(Parameters.FLASH_MODE_OFF)) {
-                            params.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
-                            camera.setParameters(params);
-                        }
+        List<String> supportedFlashModes = params.getSupportedFlashModes();
+        if (supportedFlashModes != null) {
+            try {
+                if (isFlashOn) {
+                    if (supportedFlashModes.contains(Camera.Parameters.FLASH_MODE_TORCH)) {
+                        params.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
+                        camera.setParameters(params);
                     }
-                } catch (RuntimeException RE) {
-                    CLog.e(CLog.CAMERA, "Set Torch param failed : " + RE);
+                } else {
+                    if (supportedFlashModes.contains(Parameters.FLASH_MODE_OFF)) {
+                        params.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
+                        camera.setParameters(params);
+                    }
                 }
+            } catch (RuntimeException RE) {
+                CLog.e(CLog.CAMERA, "Set Torch param failed : " + RE);
             }
-
         }
+
     }
 
 }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/NativeCamera.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/camera/NativeCamera.java
@@ -127,4 +127,10 @@ public class NativeCamera {
         }
         return false;
     }
+
+    public void setFlash(){
+        params.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
+        camera.setParameters(params);
+    }
+
 }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
@@ -303,11 +303,11 @@ public class CaptureConfiguration implements Parcelable {
 
         public Builder setFlashOption(FlashOption flashOption) {
             switch (flashOption) {
-                case HIDE:
+                case NO_FLASH:
                     configuration.allowFlashToggle = false;
                     configuration.flashStartOn = false;
                     break;
-                case HIDE_ON:
+                case ALWAYS:
                     configuration.allowFlashToggle = false;
                     configuration.flashStartOn = true;
                     break;

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
@@ -172,10 +172,6 @@ public class CaptureConfiguration implements Parcelable {
         return flashStartOn;
     }
 
-    public void setIfFlashStartOn(boolean flashStartOn){
-        this.flashStartOn = flashStartOn;
-    }
-
     public int getOutputFormat() {
         return OUTPUT_FORMAT;
     }
@@ -306,8 +302,6 @@ public class CaptureConfiguration implements Parcelable {
         }
 
         public Builder setFlashOption(FlashOption flashOption) {
-            configuration.flashStartOn = true;
-
             switch (flashOption) {
                 case HIDE:
                     configuration.allowFlashToggle = false;

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
@@ -159,14 +159,14 @@ public class CaptureConfiguration implements Parcelable {
     }
 
     /**
-     * @return If front flash toggle must be displayed before capturing video
+     * @return If flash toggle must be displayed before capturing video
      */
     public boolean getAllowFlashToggle() {
         return allowFlashToggle;
     }
 
     /**
-     * @return If front flash must be start on
+     * @return If flash must be start on
      */
     public boolean getIfFlashStartOn() {
         return flashStartOn;

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
@@ -39,7 +39,7 @@ public class CaptureConfiguration implements Parcelable {
     private int maxFilesizeBytes = NO_FILESIZE_LIMIT;
     private boolean showTimer = false;
     private boolean allowFrontFacingCamera = true;
-    private boolean allowFlash = true;
+    private boolean allowFlashToggle = true;
     private boolean flashStartOn = false;
     private int videoFramerate = PredefinedCaptureConfigurations.FPS_30;     //Default FPS is 30.
 
@@ -161,8 +161,8 @@ public class CaptureConfiguration implements Parcelable {
     /**
      * @return If front flash toggle must be displayed before capturing video
      */
-    public boolean getAllowFlash() {
-        return allowFlash;
+    public boolean getAllowFlashToggle() {
+        return allowFlashToggle;
     }
 
     /**
@@ -211,7 +211,7 @@ public class CaptureConfiguration implements Parcelable {
         dest.writeInt(videoFramerate);
         dest.writeByte((byte) (showTimer ? 1 : 0));
         dest.writeByte((byte) (allowFrontFacingCamera ? 1 : 0));
-        dest.writeByte((byte) (allowFlash ? 1 : 0));
+        dest.writeByte((byte) (allowFlashToggle ? 1 : 0));
         dest.writeByte((byte) (flashStartOn ? 1 : 0));
 
         dest.writeInt(OUTPUT_FORMAT);
@@ -244,7 +244,7 @@ public class CaptureConfiguration implements Parcelable {
         videoFramerate = in.readInt();
         showTimer = in.readByte() != 0;
         allowFrontFacingCamera = in.readByte() != 0;
-        allowFlash = in.readByte() != 0;
+        allowFlashToggle = in.readByte() != 0;
         flashStartOn = in.readByte() != 0;
 
         OUTPUT_FORMAT = in.readInt();
@@ -310,19 +310,19 @@ public class CaptureConfiguration implements Parcelable {
 
             switch (flashOption) {
                 case HIDE:
-                    configuration.allowFlash = false;
+                    configuration.allowFlashToggle = false;
                     configuration.flashStartOn = false;
                     break;
                 case HIDE_ON:
-                    configuration.allowFlash = false;
+                    configuration.allowFlashToggle = false;
                     configuration.flashStartOn = true;
                     break;
                 case START_OFF:
-                    configuration.allowFlash = true;
+                    configuration.allowFlashToggle = true;
                     configuration.flashStartOn = false;
                     break;
                 case START_ON:
-                    configuration.allowFlash = true;
+                    configuration.allowFlashToggle = true;
                     configuration.flashStartOn = true;
                     break;
             }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
@@ -18,6 +18,7 @@ package com.jmolsmobile.landscapevideocapture.configuration;
 
 import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureQuality;
 import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureResolution;
+import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.FlashOption;
 
 import android.media.MediaRecorder;
 import android.os.Parcel;
@@ -39,6 +40,7 @@ public class CaptureConfiguration implements Parcelable {
     private boolean showTimer = false;
     private boolean allowFrontFacingCamera = true;
     private boolean allowFlash = true;
+    private boolean flashStartOn = false;
     private int videoFramerate = PredefinedCaptureConfigurations.FPS_30;     //Default FPS is 30.
 
     private int OUTPUT_FORMAT = MediaRecorder.OutputFormat.MPEG_4;
@@ -163,7 +165,16 @@ public class CaptureConfiguration implements Parcelable {
         return allowFlash;
     }
 
+    /**
+     * @return If front flash must be start on
+     */
+    public boolean getIfFlashStartOn() {
+        return flashStartOn;
+    }
 
+    public void setIfFlashStartOn(boolean flashStartOn){
+        this.flashStartOn = flashStartOn;
+    }
 
     public int getOutputFormat() {
         return OUTPUT_FORMAT;
@@ -201,6 +212,7 @@ public class CaptureConfiguration implements Parcelable {
         dest.writeByte((byte) (showTimer ? 1 : 0));
         dest.writeByte((byte) (allowFrontFacingCamera ? 1 : 0));
         dest.writeByte((byte) (allowFlash ? 1 : 0));
+        dest.writeByte((byte) (flashStartOn ? 1 : 0));
 
         dest.writeInt(OUTPUT_FORMAT);
         dest.writeInt(AUDIO_SOURCE);
@@ -233,6 +245,7 @@ public class CaptureConfiguration implements Parcelable {
         showTimer = in.readByte() != 0;
         allowFrontFacingCamera = in.readByte() != 0;
         allowFlash = in.readByte() != 0;
+        flashStartOn = in.readByte() != 0;
 
         OUTPUT_FORMAT = in.readInt();
         AUDIO_SOURCE = in.readInt();
@@ -292,9 +305,29 @@ public class CaptureConfiguration implements Parcelable {
             return this;
         }
 
-        public Builder noFlashToggle() {
-            configuration.allowFlash = false;
+        public Builder setFlashOption(FlashOption flashOption) {
+            configuration.flashStartOn = true;
+
+            switch (flashOption) {
+                case HIDE:
+                    configuration.allowFlash = false;
+                    configuration.flashStartOn = false;
+                    break;
+                case HIDE_ON:
+                    configuration.allowFlash = false;
+                    configuration.flashStartOn = true;
+                    break;
+                case START_OFF:
+                    configuration.allowFlash = true;
+                    configuration.flashStartOn = false;
+                    break;
+                case START_ON:
+                    configuration.allowFlash = true;
+                    configuration.flashStartOn = true;
+                    break;
+            }
             return this;
+
         }
     }
 }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/CaptureConfiguration.java
@@ -16,12 +16,12 @@
 
 package com.jmolsmobile.landscapevideocapture.configuration;
 
+import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureQuality;
+import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureResolution;
+
 import android.media.MediaRecorder;
 import android.os.Parcel;
 import android.os.Parcelable;
-
-import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureQuality;
-import com.jmolsmobile.landscapevideocapture.configuration.PredefinedCaptureConfigurations.CaptureResolution;
 
 public class CaptureConfiguration implements Parcelable {
 
@@ -38,6 +38,7 @@ public class CaptureConfiguration implements Parcelable {
     private int maxFilesizeBytes = NO_FILESIZE_LIMIT;
     private boolean showTimer = false;
     private boolean allowFrontFacingCamera = true;
+    private boolean allowFlash = true;
     private int videoFramerate = PredefinedCaptureConfigurations.FPS_30;     //Default FPS is 30.
 
     private int OUTPUT_FORMAT = MediaRecorder.OutputFormat.MPEG_4;
@@ -155,6 +156,15 @@ public class CaptureConfiguration implements Parcelable {
         return allowFrontFacingCamera;
     }
 
+    /**
+     * @return If front flash toggle must be displayed before capturing video
+     */
+    public boolean getAllowFlash() {
+        return allowFlash;
+    }
+
+
+
     public int getOutputFormat() {
         return OUTPUT_FORMAT;
     }
@@ -190,6 +200,7 @@ public class CaptureConfiguration implements Parcelable {
         dest.writeInt(videoFramerate);
         dest.writeByte((byte) (showTimer ? 1 : 0));
         dest.writeByte((byte) (allowFrontFacingCamera ? 1 : 0));
+        dest.writeByte((byte) (allowFlash ? 1 : 0));
 
         dest.writeInt(OUTPUT_FORMAT);
         dest.writeInt(AUDIO_SOURCE);
@@ -221,6 +232,7 @@ public class CaptureConfiguration implements Parcelable {
         videoFramerate = in.readInt();
         showTimer = in.readByte() != 0;
         allowFrontFacingCamera = in.readByte() != 0;
+        allowFlash = in.readByte() != 0;
 
         OUTPUT_FORMAT = in.readInt();
         AUDIO_SOURCE = in.readInt();
@@ -277,6 +289,11 @@ public class CaptureConfiguration implements Parcelable {
 
         public Builder noCameraToggle() {
             configuration.allowFrontFacingCamera = false;
+            return this;
+        }
+
+        public Builder noFlashToggle() {
+            configuration.allowFlash = false;
             return this;
         }
     }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/PredefinedCaptureConfigurations.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/PredefinedCaptureConfigurations.java
@@ -103,4 +103,9 @@ public class PredefinedCaptureConfigurations {
         }
 
     }
+
+    public enum FlashOption {
+        HIDE,HIDE_ON, START_OFF, START_ON;
+    }
+
 }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/PredefinedCaptureConfigurations.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/configuration/PredefinedCaptureConfigurations.java
@@ -105,7 +105,7 @@ public class PredefinedCaptureConfigurations {
     }
 
     public enum FlashOption {
-        HIDE,HIDE_ON, START_OFF, START_ON;
+        NO_FLASH, ALWAYS, START_OFF, START_ON;
     }
 
 }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/preview/CapturePreview.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/preview/CapturePreview.java
@@ -16,11 +16,13 @@
 
 package com.jmolsmobile.landscapevideocapture.preview;
 
-import android.hardware.Camera;
-import android.view.SurfaceHolder;
-
 import com.jmolsmobile.landscapevideocapture.CLog;
 import com.jmolsmobile.landscapevideocapture.camera.CameraWrapper;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.hardware.Camera;
+import android.view.SurfaceHolder;
 
 import java.io.IOException;
 
@@ -124,6 +126,11 @@ public class CapturePreview implements SurfaceHolder.Callback {
 		}
 
 		return false;
+	}
+
+	@SuppressWarnings("deprecation")
+	public static boolean isFlashAvailable(Context context) {
+		return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH);
 	}
 
 

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/recorder/VideoRecorder.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/recorder/VideoRecorder.java
@@ -16,11 +16,6 @@
 
 package com.jmolsmobile.landscapevideocapture.recorder;
 
-import android.media.CamcorderProfile;
-import android.media.MediaRecorder;
-import android.media.MediaRecorder.OnInfoListener;
-import android.view.SurfaceHolder;
-
 import com.jmolsmobile.landscapevideocapture.CLog;
 import com.jmolsmobile.landscapevideocapture.VideoFile;
 import com.jmolsmobile.landscapevideocapture.camera.CameraWrapper;
@@ -30,6 +25,12 @@ import com.jmolsmobile.landscapevideocapture.camera.RecordingSize;
 import com.jmolsmobile.landscapevideocapture.configuration.CaptureConfiguration;
 import com.jmolsmobile.landscapevideocapture.preview.CapturePreview;
 import com.jmolsmobile.landscapevideocapture.preview.CapturePreviewInterface;
+
+import android.hardware.Camera;
+import android.media.CamcorderProfile;
+import android.media.MediaRecorder;
+import android.media.MediaRecorder.OnInfoListener;
+import android.view.SurfaceHolder;
 
 import java.io.IOException;
 
@@ -212,6 +213,17 @@ public class VideoRecorder implements OnInfoListener, CapturePreviewInterface {
             recorder.release();
             setMediaRecorder(null);
         }
+    }
+
+    public void setFlash(boolean isFlashOn){
+
+        Camera.Parameters params =  mCameraWrapper.getCamera().getParameters();
+        if (isFlashOn) {
+            params.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
+        }else {
+            params.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
+        }
+        mCameraWrapper.getCamera().setParameters(params);
     }
 
     public void releaseAllResources() {

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/recorder/VideoRecorder.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/recorder/VideoRecorder.java
@@ -73,7 +73,7 @@ public class VideoRecorder implements OnInfoListener, CapturePreviewInterface {
         mVideoCapturePreview = new CapturePreview(this, mCameraWrapper, previewHolder);
     }
 
-    public void toggleRecording(boolean useFlash) throws AlreadyUsedException {
+    public void toggleRecording() throws AlreadyUsedException {
         if (mCameraWrapper == null) {
             throw new AlreadyUsedException();
         }
@@ -81,12 +81,11 @@ public class VideoRecorder implements OnInfoListener, CapturePreviewInterface {
         if (isRecording()) {
             stopRecording(null);
         } else {
-            startRecording(useFlash);
-
+            startRecording();
         }
     }
 
-    protected void startRecording(boolean useFlash) {
+    protected void startRecording() {
         mRecording = false;
 
         if (!initRecorder()) return;

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/recorder/VideoRecorder.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/recorder/VideoRecorder.java
@@ -96,10 +96,6 @@ public class VideoRecorder implements OnInfoListener, CapturePreviewInterface {
         mRecording = true;
         mRecorderInterface.onRecordingStarted();
         CLog.d(CLog.RECORDER, "Successfully started recording - outputfile: " + mVideoFile.getFullPath());
-
-        if(useFlash && !mUseFrontFacingCamera ) {
-            mCameraWrapper.setFlash();
-        }
     }
 
     public void stopRecording(String message) {

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/RecordingButtonInterface.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/RecordingButtonInterface.java
@@ -26,4 +26,6 @@ public interface RecordingButtonInterface {
 
     void onSwitchCamera(boolean isFrontFacingSelected);
 
+    void onFlashButtonClicked(boolean isFlashOn);
+
 }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/RecordingButtonInterface.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/RecordingButtonInterface.java
@@ -18,7 +18,7 @@ package com.jmolsmobile.landscapevideocapture.view;
 
 public interface RecordingButtonInterface {
 
-    void onRecordButtonClicked();
+    void onRecordButtonClicked(boolean useFlash);
 
     void onAcceptButtonClicked();
 

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/RecordingButtonInterface.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/RecordingButtonInterface.java
@@ -18,7 +18,7 @@ package com.jmolsmobile.landscapevideocapture.view;
 
 public interface RecordingButtonInterface {
 
-    void onRecordButtonClicked(boolean useFlash);
+    void onRecordButtonClicked();
 
     void onAcceptButtonClicked();
 

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
@@ -17,6 +17,7 @@
 package com.jmolsmobile.landscapevideocapture.view;
 
 import com.jmolsmobile.landscapevideocapture.R;
+import com.jmolsmobile.landscapevideocapture.camera.CameraWrapper;
 import com.jmolsmobile.landscapevideocapture.preview.CapturePreview;
 
 import android.content.Context;
@@ -104,11 +105,13 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
         mFlashBtnIv.setVisibility(isFlashSwitchingEnabled ? View.VISIBLE : View.INVISIBLE);
     }
 
-    public void setFlashStartOption(boolean isFlashStartOn){
+    public void setFlashStartOption(CameraWrapper mCameraWrapper, boolean isFlashStartOn){
         this.isFlashOn = isFlashStartOn;
         mFlashBtnIv.setImageResource(isFlashStartOn ?
                 R.drawable.ic_flash_on :
                 R.drawable.ic_flash_off);
+
+        mCameraWrapper.setFlash(isFlashStartOn);
     }
 
     public void setCameraFacing(boolean isFrontFacing) {

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
@@ -104,6 +104,13 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
         mFlashBtnIv.setVisibility(isFlashSwitchingEnabled ? View.VISIBLE : View.INVISIBLE);
     }
 
+    public void setFlashStartOption(boolean isFlashStartOn){
+        this.isFlashOn = isFlashStartOn;
+        mFlashBtnIv.setImageResource(isFlashStartOn ?
+                R.drawable.ic_flash_on :
+                R.drawable.ic_flash_off);
+    }
+
     public void setCameraFacing(boolean isFrontFacing) {
         if (!isCameraSwitchingEnabled) return;
         isFrontCameraEnabled = isFrontFacing;

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
@@ -16,6 +16,9 @@
 
 package com.jmolsmobile.landscapevideocapture.view;
 
+import com.jmolsmobile.landscapevideocapture.R;
+import com.jmolsmobile.landscapevideocapture.preview.CapturePreview;
+
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Handler;
@@ -30,15 +33,13 @@ import android.widget.ImageView;
 import android.widget.ImageView.ScaleType;
 import android.widget.TextView;
 
-import com.jmolsmobile.landscapevideocapture.R;
-import com.jmolsmobile.landscapevideocapture.preview.CapturePreview;
-
 public class VideoCaptureView extends FrameLayout implements OnClickListener {
 
     private ImageView mDeclineBtnIv;
     private ImageView mAcceptBtnIv;
     private ImageView mRecordBtnIv;
     private ImageView mChangeCameraIv;
+    private ImageView mFlashBtnIv;
 
     private SurfaceView mSurfaceView;
     private ImageView mThumbnailIv;
@@ -50,6 +51,8 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
     private boolean mShowTimer;
     private boolean isFrontCameraEnabled;
     private boolean isCameraSwitchingEnabled;
+    private boolean isFlashOn;
+    private boolean isFlashSwitchingEnabled;
 
     public VideoCaptureView(Context context) {
         super(context);
@@ -73,11 +76,13 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
         mAcceptBtnIv = (ImageView) videoCapture.findViewById(R.id.videocapture_acceptbtn_iv);
         mDeclineBtnIv = (ImageView) videoCapture.findViewById(R.id.videocapture_declinebtn_iv);
         mChangeCameraIv = (ImageView) videoCapture.findViewById(R.id.change_camera_iv);
+        mFlashBtnIv = (ImageView) videoCapture.findViewById(R.id.flash_iv);
 
         mRecordBtnIv.setOnClickListener(this);
         mAcceptBtnIv.setOnClickListener(this);
         mDeclineBtnIv.setOnClickListener(this);
         mChangeCameraIv.setOnClickListener(this);
+        mFlashBtnIv.setOnClickListener(this);
 
         mThumbnailIv = (ImageView) videoCapture.findViewById(R.id.videocapture_preview_iv);
         mSurfaceView = (SurfaceView) videoCapture.findViewById(R.id.videocapture_preview_sv);
@@ -92,6 +97,11 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
     public void setCameraSwitchingEnabled(boolean isCameraSwitchingEnabled) {
         this.isCameraSwitchingEnabled = isCameraSwitchingEnabled;
         mChangeCameraIv.setVisibility(isCameraSwitchingEnabled ? View.VISIBLE : View.INVISIBLE);
+    }
+
+    public void setFlashSwitchingEnabled(boolean isFlashSwitchingEnabled, boolean isFrontCameraEnabled) {
+        this.isFlashSwitchingEnabled = isFlashSwitchingEnabled && !isFrontCameraEnabled;
+        mFlashBtnIv.setVisibility(isFlashSwitchingEnabled ? View.VISIBLE : View.INVISIBLE);
     }
 
     public void setCameraFacing(boolean isFrontFacing) {
@@ -111,6 +121,7 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
         mChangeCameraIv.setVisibility(allowCameraSwitching() ? VISIBLE : INVISIBLE);
         mRecordBtnIv.setVisibility(View.VISIBLE);
         mAcceptBtnIv.setVisibility(View.GONE);
+        mFlashBtnIv.setVisibility(allowFlashSwitching()? VISIBLE : INVISIBLE);
         mDeclineBtnIv.setVisibility(View.GONE);
         mThumbnailIv.setVisibility(View.GONE);
         mSurfaceView.setVisibility(View.VISIBLE);
@@ -131,6 +142,7 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
         mRecordBtnIv.setSelected(true);
         mRecordBtnIv.setVisibility(View.VISIBLE);
         mChangeCameraIv.setVisibility(View.INVISIBLE);
+        mFlashBtnIv.setVisibility(View.INVISIBLE);
         mAcceptBtnIv.setVisibility(View.GONE);
         mDeclineBtnIv.setVisibility(View.GONE);
         mThumbnailIv.setVisibility(View.GONE);
@@ -147,6 +159,7 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
         mRecordBtnIv.setVisibility(View.INVISIBLE);
         mAcceptBtnIv.setVisibility(View.VISIBLE);
         mChangeCameraIv.setVisibility(View.INVISIBLE);
+        mFlashBtnIv.setVisibility(View.INVISIBLE);
         mDeclineBtnIv.setVisibility(View.VISIBLE);
         mThumbnailIv.setVisibility(View.VISIBLE);
         mSurfaceView.setVisibility(View.GONE);
@@ -174,6 +187,11 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
             mChangeCameraIv.setImageResource(isFrontCameraEnabled ?
                     R.drawable.ic_change_camera_front : R.drawable.ic_change_camera_back);
             mRecordingInterface.onSwitchCamera(isFrontCameraEnabled);
+        } else if (v.getId() == mFlashBtnIv.getId()) {
+            isFlashOn = !isFlashOn;
+            mFlashBtnIv.setImageResource(isFlashOn ?
+                    R.drawable.ic_flash_on : R.drawable.ic_flash_off);
+            mRecordingInterface.onFlashButtonClicked(isFlashOn);
         }
 
     }
@@ -188,5 +206,9 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
 
     private boolean allowCameraSwitching() {
         return CapturePreview.isFrontCameraAvailable() && isCameraSwitchingEnabled;
+    }
+
+    private boolean allowFlashSwitching() {
+        return CapturePreview.isFlashAvailable(getContext()) && isFlashSwitchingEnabled;
     }
 }

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
@@ -184,7 +184,7 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
         if (mRecordingInterface == null) return;
 
         if (v.getId() == mRecordBtnIv.getId()) {
-            mRecordingInterface.onRecordButtonClicked();
+            mRecordingInterface.onRecordButtonClicked(isFlashOn);
         } else if (v.getId() == mAcceptBtnIv.getId()) {
             mRecordingInterface.onAcceptButtonClicked();
         } else if (v.getId() == mDeclineBtnIv.getId()) {

--- a/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
+++ b/library/src/main/java/com/jmolsmobile/landscapevideocapture/view/VideoCaptureView.java
@@ -187,7 +187,7 @@ public class VideoCaptureView extends FrameLayout implements OnClickListener {
         if (mRecordingInterface == null) return;
 
         if (v.getId() == mRecordBtnIv.getId()) {
-            mRecordingInterface.onRecordButtonClicked(isFlashOn);
+            mRecordingInterface.onRecordButtonClicked();
         } else if (v.getId() == mAcceptBtnIv.getId()) {
             mRecordingInterface.onAcceptButtonClicked();
         } else if (v.getId() == mDeclineBtnIv.getId()) {

--- a/library/src/main/res/drawable/ic_flash_off.xml
+++ b/library/src/main/res/drawable/ic_flash_off.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M3.27,3L2,4.27l5,5V13h3v9l3.58,-6.14L17.73,20 19,18.73 3.27,3zM17,10h-4l4,-8H7v2.18l8.46,8.46L17,10z"/>
+</vector>

--- a/library/src/main/res/drawable/ic_flash_on.xml
+++ b/library/src/main/res/drawable/ic_flash_on.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M7,2v11h3v9l7,-12h-4l4,-8z"/>
+</vector>

--- a/library/src/main/res/layout/view_videocapture.xml
+++ b/library/src/main/res/layout/view_videocapture.xml
@@ -15,7 +15,6 @@
   -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
                 android:id="@+id/videocapture_container_rl"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -36,6 +35,21 @@
         android:visibility="gone"/>
 
     <ImageView
+            android:id="@+id/change_camera_iv"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:clickable="true"
+            android:padding="8dp"
+            android:src="@drawable/ic_change_camera_front"
+            android:visibility="visible"
+            android:layout_marginRight="14dp"
+            android:layout_marginBottom="28dp"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="14dp"/>
+
+    <ImageView
         android:id="@+id/videocapture_recordbtn_iv"
         android:layout_width="100dp"
         android:layout_height="100dp"
@@ -46,19 +60,19 @@
         android:clickable="true"/>
 
     <ImageView
-        android:id="@+id/change_camera_iv"
+        android:id="@+id/flash_iv"
         android:layout_width="48dp"
         android:layout_height="48dp"
         android:clickable="true"
         android:padding="8dp"
-        android:src="@drawable/ic_change_camera_front"
+        android:src="@drawable/ic_flash_off"
         android:visibility="visible"
-        android:layout_marginRight="14dp"
-        android:layout_marginBottom="28dp"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true"
-        android:layout_marginEnd="14dp"/>
+        android:layout_marginTop="10dp"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_marginLeft="14dp"
+        android:layout_marginStart="14dp"/>
 
     <ImageView
         android:id="@+id/videocapture_acceptbtn_iv"


### PR DESCRIPTION
- This will allow the user to activate flash when recording by adding a flash toggle button on the top left (See the screenshot below).

![screenshot_20180203-182804](https://user-images.githubusercontent.com/30046786/35746596-993b6f6e-0847-11e8-9499-90042b5b5710.png)

- The developer can also hide flash toggle using _builder.noFlashToggle();_ while creating CaptureConfiguration. By default, flash toggle switch is visible and off.


_It's my first pull request, so I must admit that I was very inspired by Kevalpatel's work done on the front and rear facing camera switch and on his PR message ;)_

_Refs Pull#34 and Issue#13_